### PR TITLE
Support enqueuelocation for ships

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1590,7 +1590,11 @@ bool Empire::ProducibleItem(const ProductionQueue::ProductionItem& item, int loc
 }
 
 bool Empire::EnqueuableItem(BuildType build_type, const std::string& name, int location) const {
-    if (build_type != BT_BUILDING)
+    // special case to check for ships being passed with names, not design ids
+    if (build_type == BT_SHIP)
+        throw std::invalid_argument("Empire::EnqueuableItem was passed BuildType BT_SHIP with a name, but ship designs are tracked by number");
+
+    if (build_type == BT_BUILDING && !BuildingTypeAvailable(name))
         return false;
 
     const BuildingType* building_type = GetBuildingType(name);
@@ -1601,8 +1605,58 @@ bool Empire::EnqueuableItem(BuildType build_type, const std::string& name, int l
     if (!build_location)
         return false;
 
-    // specified location must be a valid production location for that building type
-    return building_type->EnqueueLocation(m_id, location);
+    if (build_type == BT_BUILDING) {
+        // specified location must be a valid production location for that building type
+        return building_type->EnqueueLocation(m_id, location);
+
+    } else {
+        ErrorLogger() << "Empire::EnqueuableItem was passed an invalid BuildType";
+        return false;
+    }
+}
+
+bool Empire::EnqueuableItem(BuildType build_type, int design_id, int location) const {
+    // special case to check for buildings being passed with ids, not names
+    if (build_type == BT_BUILDING)
+        throw std::invalid_argument("Empire::EnqueuableItem was passed BuildType BT_BUILDING with a design id number, but these types are tracked by name");
+
+    if (build_type == BT_SHIP && !ShipDesignAvailable(design_id))
+        return false;
+
+    // design must be known to this empire
+    const ShipDesign* ship_design = GetShipDesign(design_id);
+    if (!ship_design || !ship_design->Producible())
+        return false;
+
+    TemporaryPtr<UniverseObject> build_location = GetUniverseObject(location);
+    if (!build_location) return false;
+
+    if (build_type == BT_SHIP) {
+        // specified location must be a valid production location for this design
+      
+        // TODO: The painful road to BT_SHIP EnqueueLocation
+        //       Left for a separate issue : discussions is needed to activate ship_design->EnqueueLocation
+        // Heavy modifications for immobile ships containing CO_OUTPOST_POD CO_COLONY_POD CO_SUSPEND_ANIM_POD:
+        // 1. Need to declare/modify bool ShipDesign::Enqueue/ProductionLocation(int empire_id, int location_id) in ShipDesign.cpp
+        // 2. Need to introduce HullType.m_enqeuelocation and all the stuff for that.
+      
+        // return ship_design->EnqueueLocation(m_id, location);
+        return true;
+
+    } else {
+        ErrorLogger() << "Empire::EnqueuableItem was passed an invalid BuildType";
+        return false;
+    }
+}
+
+bool Empire::EnqueuableItem(const ProductionQueue::ProductionItem& item, int location) const {
+    if (item.build_type == BT_BUILDING)
+        return EnqueuableItem(item.build_type, item.name, location);
+    else if (item.build_type == BT_SHIP)
+        return EnqueuableItem(item.build_type, item.design_id, location);
+    else
+        throw std::invalid_argument("Empire::EnqueuableItem was passed a ProductionItem with an invalid BuildType");
+    return false;
 }
 
 int Empire::NumSitRepEntries(int turn/* = INVALID_GAME_TURN*/) const {

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1634,14 +1634,15 @@ bool Empire::EnqueuableItem(BuildType build_type, int design_id, int location) c
     if (build_type == BT_SHIP) {
         // specified location must be a valid production location for this design
       
-        // TODO: The painful road to BT_SHIP EnqueueLocation
-        //       Left for a separate issue : discussions is needed to activate ship_design->EnqueueLocation
-        // Heavy modifications for immobile ships containing CO_OUTPOST_POD CO_COLONY_POD CO_SUSPEND_ANIM_POD:
-        // 1. Need to declare/modify bool ShipDesign::Enqueue/ProductionLocation(int empire_id, int location_id) in ShipDesign.cpp
-        // 2. Need to introduce HullType.m_enqeuelocation and all the stuff for that.
+        // TODO: Left for discussion. Two options here (using enqueuelocation scripts or)
+        //
+        // A. using enqueuelocation scripts (seems to be no plan for ttat).
+        //
+        // B. An adhoc ship_design->EnqueueLocation() with conditions hard-coded for immobile colony ships/base
+        // (drawback: no possibility for scripting)
       
-        // return ship_design->EnqueueLocation(m_id, location);
-        return true;
+        return ship_design->EnqueueLocation(m_id, location);
+        // return true;
 
     } else {
         ErrorLogger() << "Empire::EnqueuableItem was passed an invalid BuildType";

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -349,6 +349,8 @@ public:
     bool                    ProducibleItem(const ProductionQueue::ProductionItem& item, int location) const;    ///< Returns true iff this empire can produce the specified item at the specified location.
 
     bool                    EnqueuableItem(BuildType build_type, const std::string& name, int location) const;  ///< Returns true iff this empire can enqueue the specified item at the specified location.
+    bool                    EnqueuableItem(BuildType build_type, int design_id, int location) const;            ///< Returns true iff this empire can enqueue the specified item at the specified location.
+    bool                    EnqueuableItem(const ProductionQueue::ProductionItem& item, int location) const;    ///< Returns true iff this empire can enqueue the specified item at the specified location.
 
     bool                    HasExploredSystem(int ID) const;                            ///< returns  true if the given item is in the appropriate list, false if it is not.
 

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -274,7 +274,7 @@ namespace {
             push_back(m_panel);
 
             if (const Empire* empire = GetEmpire(m_empire_id)) {
-                if (!empire->ProducibleItem(m_item, m_location_id)) {
+                if (!empire->ProducibleItem(m_item, m_location_id)  || !empire->EnqueuableItem(m_item, m_location_id) ) {
                     this->Disable(true);
                     m_panel->Disable(true);
                 }

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -487,6 +487,7 @@ public:
     //@}
 
     bool                            ProductionLocation(int empire_id, int location_id) const;   ///< returns true iff the empire with ID empire_id can produce this design at the location with location_id
+    bool                            EnqueueLocation(int empire_id, int location_id) const;      ///< returns true iff the empire with ID empire_id can enqueue this design at the location with location_id
 
     /** \name Mutators */ //@{
     void                            SetID(int id);                          ///< sets the ID number of the design to \a id .  Should only be used by Universe class when inserting new design into Universe.


### PR DESCRIPTION
Visual feedback if unmet enqueuelocation condition for (cryonic) outpost/colony base
(This PR includes the same feature for BT_BUILDING)
- Condition based on condition for shipdesign->CanColonize() and shipdesign->Speed() == 0.0

Left for discussion: 
- In 0.4.4 outpost/colony base are moveable through stargates, is there a need for this?
- Does this commit really change the gameplay (allowing parallel constructions of bases but blocking them once the system is fully colonized)
- Except Empire::Researchable stargate technology, what are other possibilities? 

![freeorion_grayed_nonenqueable_colony_base](https://cloud.githubusercontent.com/assets/7627533/7821667/a8ea4be6-03f0-11e5-9f62-d00201577899.jpeg)

![freeorion_grayed_nonenqueable](https://cloud.githubusercontent.com/assets/7627533/7821668/a8eef592-03f0-11e5-8baf-4547e7ab946c.jpeg)
